### PR TITLE
test: Add 57 unit tests for critical paths (#146 Batch 1)

### DIFF
--- a/app/src/test/java/org/cosmic/cosmicconnect/DeviceInfoTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/DeviceInfoTest.kt
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: 2026 COSMIC Connect Contributors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+package org.cosmic.cosmicconnect
+
+import io.mockk.mockk
+import org.cosmic.cosmicconnect.Core.NetworkPacket
+import org.cosmic.cosmicconnect.Core.PacketType
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.cert.Certificate
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceInfoTest {
+
+    private val mockCertificate: Certificate = mockk(relaxed = true)
+
+    // ========================================================================
+    // isValidDeviceId
+    // ========================================================================
+
+    @Test
+    fun `isValidDeviceId accepts 32-char alphanumeric ID`() {
+        assertTrue(DeviceInfo.isValidDeviceId("abcdef1234567890abcdef1234567890"))
+    }
+
+    @Test
+    fun `isValidDeviceId accepts 36-char ID with underscores and hyphens`() {
+        assertTrue(DeviceInfo.isValidDeviceId("4dc6f1cb_ef38_4ce3_a9c6_e469cc6ba147"))
+    }
+
+    @Test
+    fun `isValidDeviceId rejects too short ID`() {
+        assertFalse(DeviceInfo.isValidDeviceId("abc123"))
+    }
+
+    @Test
+    fun `isValidDeviceId rejects too long ID`() {
+        assertFalse(DeviceInfo.isValidDeviceId("a".repeat(39)))
+    }
+
+    @Test
+    fun `isValidDeviceId rejects special characters`() {
+        assertFalse(DeviceInfo.isValidDeviceId("abcdef1234567890abcdef123456789!"))
+    }
+
+    @Test
+    fun `isValidDeviceId rejects empty string`() {
+        assertFalse(DeviceInfo.isValidDeviceId(""))
+    }
+
+    // ========================================================================
+    // fromIdentityPacketAndCert
+    // ========================================================================
+
+    @Test
+    fun `fromIdentityPacketAndCert parses all fields`() {
+        val inCaps = JSONArray(listOf("cconnect.ping", "cconnect.battery")).toString()
+        val outCaps = JSONArray(listOf("cconnect.clipboard")).toString()
+        val packet = NetworkPacket(
+            id = 1L,
+            type = PacketType.IDENTITY,
+            body = mapOf(
+                "deviceId" to "abcdef1234567890abcdef1234567890",
+                "deviceName" to "Test Device",
+                "deviceType" to "phone",
+                "protocolVersion" to 8,
+                "incomingCapabilities" to inCaps,
+                "outgoingCapabilities" to outCaps
+            )
+        )
+
+        val info = DeviceInfo.fromIdentityPacketAndCert(packet, mockCertificate)
+
+        assertEquals("abcdef1234567890abcdef1234567890", info.id)
+        assertEquals("Test Device", info.name)
+        assertEquals(DeviceType.PHONE, info.type)
+        assertEquals(8, info.protocolVersion)
+        assertEquals(setOf("cconnect.ping", "cconnect.battery"), info.incomingCapabilities)
+        assertEquals(setOf("cconnect.clipboard"), info.outgoingCapabilities)
+    }
+
+    @Test
+    fun `fromIdentityPacketAndCert filters name with special characters`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = PacketType.IDENTITY,
+            body = mapOf(
+                "deviceId" to "abcdef1234567890abcdef1234567890",
+                "deviceName" to "My \"Device\" (test)",
+                "deviceType" to "desktop",
+                "protocolVersion" to 7
+            )
+        )
+
+        val info = DeviceInfo.fromIdentityPacketAndCert(packet, mockCertificate)
+        assertEquals("My Device test", info.name)
+    }
+
+    // ========================================================================
+    // isValidIdentityPacket
+    // ========================================================================
+
+    @Test
+    fun `isValidIdentityPacket returns true for valid packet`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = PacketType.IDENTITY,
+            body = mapOf(
+                "deviceId" to "abcdef1234567890abcdef1234567890",
+                "deviceName" to "Test Device"
+            )
+        )
+        assertTrue(DeviceInfo.isValidIdentityPacket(packet))
+    }
+
+    @Test
+    fun `isValidIdentityPacket returns false for wrong type`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = PacketType.PING,
+            body = mapOf(
+                "deviceId" to "abcdef1234567890abcdef1234567890",
+                "deviceName" to "Test Device"
+            )
+        )
+        assertFalse(DeviceInfo.isValidIdentityPacket(packet))
+    }
+
+    @Test
+    fun `isValidIdentityPacket returns false for blank name`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = PacketType.IDENTITY,
+            body = mapOf(
+                "deviceId" to "abcdef1234567890abcdef1234567890",
+                "deviceName" to ""
+            )
+        )
+        assertFalse(DeviceInfo.isValidIdentityPacket(packet))
+    }
+
+    @Test
+    fun `isValidIdentityPacket returns false for invalid deviceId`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = PacketType.IDENTITY,
+            body = mapOf(
+                "deviceId" to "short",
+                "deviceName" to "Test Device"
+            )
+        )
+        assertFalse(DeviceInfo.isValidIdentityPacket(packet))
+    }
+
+    // ========================================================================
+    // DeviceType.fromString
+    // ========================================================================
+
+    @Test
+    fun `DeviceType fromString round-trips all types`() {
+        assertEquals(DeviceType.PHONE, DeviceType.fromString("phone"))
+        assertEquals(DeviceType.TABLET, DeviceType.fromString("tablet"))
+        assertEquals(DeviceType.TV, DeviceType.fromString("tv"))
+        assertEquals(DeviceType.LAPTOP, DeviceType.fromString("laptop"))
+        assertEquals(DeviceType.DESKTOP, DeviceType.fromString("desktop"))
+        assertEquals(DeviceType.DESKTOP, DeviceType.fromString("unknown"))
+    }
+
+    @Test
+    fun `DeviceType toString round-trips all types`() {
+        assertEquals("phone", DeviceType.PHONE.toString())
+        assertEquals("tablet", DeviceType.TABLET.toString())
+        assertEquals("tv", DeviceType.TV.toString())
+        assertEquals("laptop", DeviceType.LAPTOP.toString())
+        assertEquals("desktop", DeviceType.DESKTOP.toString())
+    }
+}

--- a/app/src/test/java/org/cosmic/cosmicconnect/Helpers/DeviceHelperTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/Helpers/DeviceHelperTest.kt
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: 2026 COSMIC Connect Contributors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+package org.cosmic.cosmicconnect.Helpers
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceHelperTest {
+
+    // ========================================================================
+    // filterInvalidCharactersFromDeviceName
+    // ========================================================================
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceName removes special characters`() {
+        val input = """He"ll'o, W;o:r.l!d? (test)[array]<angle>"""
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceName(input)
+        assertEquals("Hello World testarrayangle", result)
+    }
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceName preserves valid characters`() {
+        val input = "My Device-Name_123 Test"
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceName(input)
+        assertEquals("My Device-Name_123 Test", result)
+    }
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceName handles empty string`() {
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceName("")
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceName handles all invalid characters`() {
+        val input = "\"',;:.!?()[]<>"
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceName(input)
+        assertEquals("", result)
+    }
+
+    // ========================================================================
+    // filterInvalidCharactersFromDeviceNameAndLimitLength
+    // ========================================================================
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceNameAndLimitLength truncates to 32 chars`() {
+        val input = "A".repeat(50)
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceNameAndLimitLength(input)
+        assertEquals(32, result.length)
+        assertEquals("A".repeat(32), result)
+    }
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceNameAndLimitLength trims whitespace before truncation`() {
+        val input = "   My Device   "
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceNameAndLimitLength(input)
+        assertEquals("My Device", result)
+    }
+
+    @Test
+    fun `filterInvalidCharactersFromDeviceNameAndLimitLength filters and truncates combined`() {
+        val input = "  " + "A!B".repeat(20) + "  "
+        val result = DeviceHelper.filterInvalidCharactersFromDeviceNameAndLimitLength(input)
+        assertTrue(result.length <= 32)
+        assertTrue(!result.contains("!"))
+    }
+
+    // ========================================================================
+    // Constants
+    // ========================================================================
+
+    @Test
+    fun `PROTOCOL_VERSION is 8`() {
+        assertEquals(8, DeviceHelper.PROTOCOL_VERSION)
+    }
+
+    @Test
+    fun `MAX_DEVICE_NAME_LENGTH is 32`() {
+        assertEquals(32, DeviceHelper.MAX_DEVICE_NAME_LENGTH)
+    }
+}

--- a/app/src/test/java/org/cosmic/cosmicconnect/PairingHandlerTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/PairingHandlerTest.kt
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: 2026 COSMIC Connect Contributors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+package org.cosmic.cosmicconnect
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.cosmic.cosmicconnect.Core.NetworkPacket
+import org.cosmic.cosmicconnect.Core.PacketType
+import org.cosmic.cosmicconnect.Core.TransferPacket
+import org.cosmic.cosmicconnect.Helpers.SecurityHelpers.SslHelper
+import org.cosmic.cosmicconnect.PairingHandler.PairState
+import org.cosmic.cosmicconnect.PairingHandler.PairingCallback
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.security.KeyPairGenerator
+import java.security.cert.Certificate
+
+@RunWith(RobolectricTestRunner::class)
+class PairingHandlerTest {
+
+    private lateinit var device: Device
+    private lateinit var callback: PairingCallback
+    private lateinit var sslHelper: SslHelper
+    private lateinit var mockCertificateA: Certificate
+    private lateinit var mockCertificateB: Certificate
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+
+        device = mockk(relaxed = true)
+        every { device.context } returns context
+        every { device.protocolVersion } returns 7
+        every { device.deviceId } returns "abcdef1234567890abcdef1234567890"
+
+        callback = mockk(relaxed = true)
+        sslHelper = mockk(relaxed = true)
+
+        // Generate real key pairs for deterministic verification key tests
+        val keyGen = KeyPairGenerator.getInstance("RSA")
+        keyGen.initialize(1024)
+        mockCertificateA = mockk(relaxed = true)
+        mockCertificateB = mockk(relaxed = true)
+        val keyPairA = keyGen.generateKeyPair()
+        val keyPairB = keyGen.generateKeyPair()
+        every { mockCertificateA.publicKey } returns keyPairA.public
+        every { mockCertificateB.publicKey } returns keyPairB.public
+
+        every { sslHelper.certificate } returns mockCertificateA
+        every { device.certificate } returns mockCertificateB
+    }
+
+    private fun createHandler(state: PairState = PairState.NotPaired): PairingHandler {
+        return PairingHandler(device, callback, state, sslHelper)
+    }
+
+    private fun pairPacket(pair: Boolean, timestamp: Long? = null): TransferPacket {
+        val body = mutableMapOf<String, Any>("pair" to pair)
+        if (timestamp != null) {
+            body["timestamp"] = timestamp
+        }
+        return TransferPacket(
+            NetworkPacket(id = 1L, type = PacketType.PAIR, body = body)
+        )
+    }
+
+    // ========================================================================
+    // packetReceived — pair=true transitions
+    // ========================================================================
+
+    @Test
+    fun `pair true from NotPaired transitions to RequestedByPeer v7`() {
+        val handler = createHandler(PairState.NotPaired)
+        handler.packetReceived(pairPacket(pair = true))
+
+        assertEquals(PairState.RequestedByPeer, handler.state)
+        verify { callback.incomingPairRequest() }
+    }
+
+    @Test
+    fun `pair true from Requested transitions to Paired`() {
+        val handler = createHandler(PairState.Requested)
+        handler.packetReceived(pairPacket(pair = true))
+
+        assertEquals(PairState.Paired, handler.state)
+        verify { callback.pairingSuccessful() }
+    }
+
+    @Test
+    fun `pair true from RequestedByPeer is ignored`() {
+        val handler = createHandler(PairState.RequestedByPeer)
+        handler.packetReceived(pairPacket(pair = true))
+
+        assertEquals(PairState.RequestedByPeer, handler.state)
+        verify(exactly = 0) { callback.incomingPairRequest() }
+        verify(exactly = 0) { callback.pairingSuccessful() }
+    }
+
+    @Test
+    fun `pair true from Paired unpairs then re-requests v7`() {
+        val handler = createHandler(PairState.Paired)
+        handler.packetReceived(pairPacket(pair = true))
+
+        assertEquals(PairState.RequestedByPeer, handler.state)
+        verify { callback.unpaired(device) }
+        verify { callback.incomingPairRequest() }
+    }
+
+    // ========================================================================
+    // packetReceived — pair=false transitions
+    // ========================================================================
+
+    @Test
+    fun `pair false from Paired transitions to NotPaired`() {
+        val handler = createHandler(PairState.Paired)
+        handler.packetReceived(pairPacket(pair = false))
+
+        assertEquals(PairState.NotPaired, handler.state)
+        verify { callback.unpaired(device) }
+    }
+
+    @Test
+    fun `pair false from Requested transitions to NotPaired with pairingFailed`() {
+        val handler = createHandler(PairState.Requested)
+        handler.packetReceived(pairPacket(pair = false))
+
+        assertEquals(PairState.NotPaired, handler.state)
+        verify { callback.pairingFailed(any()) }
+    }
+
+    @Test
+    fun `pair false from NotPaired stays NotPaired`() {
+        val handler = createHandler(PairState.NotPaired)
+        handler.packetReceived(pairPacket(pair = false))
+
+        assertEquals(PairState.NotPaired, handler.state)
+        verify(exactly = 0) { callback.unpaired(any()) }
+        verify(exactly = 0) { callback.pairingFailed(any()) }
+    }
+
+    // ========================================================================
+    // Protocol v8 timestamp checks
+    // ========================================================================
+
+    @Test
+    fun `pair true v8 with bad timestamp fails pairing`() {
+        every { device.protocolVersion } returns 8
+        val handler = createHandler(PairState.NotPaired)
+
+        handler.packetReceived(pairPacket(pair = true, timestamp = -1L))
+
+        assertEquals(PairState.NotPaired, handler.state)
+        verify { callback.unpaired(device) }
+    }
+
+    @Test
+    fun `pair true v8 with good timestamp transitions to RequestedByPeer`() {
+        every { device.protocolVersion } returns 8
+        val handler = createHandler(PairState.NotPaired)
+
+        val currentTimestamp = System.currentTimeMillis() / 1000L
+        handler.packetReceived(pairPacket(pair = true, timestamp = currentTimestamp))
+
+        assertEquals(PairState.RequestedByPeer, handler.state)
+        verify { callback.incomingPairRequest() }
+    }
+
+    @Test
+    fun `pair true v8 with timestamp too far in future fails`() {
+        every { device.protocolVersion } returns 8
+        val handler = createHandler(PairState.NotPaired)
+
+        val farFuture = (System.currentTimeMillis() / 1000L) + 3600L // 1 hour ahead
+        handler.packetReceived(pairPacket(pair = true, timestamp = farFuture))
+
+        assertEquals(PairState.NotPaired, handler.state)
+        verify { callback.pairingFailed(any()) }
+    }
+
+    // ========================================================================
+    // pairingDone — callback exception handling
+    // ========================================================================
+
+    @Test
+    fun `pairingDone handles callback exception gracefully`() {
+        every { callback.pairingSuccessful() } throws RuntimeException("callback error")
+        val handler = createHandler(PairState.Requested)
+
+        handler.pairingDone()
+
+        assertEquals(PairState.NotPaired, handler.state)
+    }
+
+    // ========================================================================
+    // Companion methods — verification keys
+    // ========================================================================
+
+    @Test
+    fun `getVerificationKey is deterministic for same inputs`() {
+        val key1 = PairingHandler.getVerificationKey(mockCertificateA, mockCertificateB, 1000L)
+        val key2 = PairingHandler.getVerificationKey(mockCertificateA, mockCertificateB, 1000L)
+        assertEquals(key1, key2)
+        assertNotNull(key1)
+        assertEquals(8, key1.length)
+    }
+
+    @Test
+    fun `getVerificationKeyV7 is deterministic for same inputs`() {
+        val key1 = PairingHandler.getVerificationKeyV7(mockCertificateA, mockCertificateB)
+        val key2 = PairingHandler.getVerificationKeyV7(mockCertificateA, mockCertificateB)
+        assertEquals(key1, key2)
+        assertNotNull(key1)
+        assertEquals(8, key1.length)
+    }
+}

--- a/app/src/test/java/org/cosmic/cosmicconnect/PairingHandlerTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/PairingHandlerTest.kt
@@ -17,15 +17,31 @@ import org.cosmic.cosmicconnect.PairingHandler.PairingCallback
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import java.security.KeyPairGenerator
+import java.security.PublicKey
 import java.security.cert.Certificate
 
 @RunWith(RobolectricTestRunner::class)
 class PairingHandlerTest {
+
+    companion object {
+        private lateinit var publicKeyA: PublicKey
+        private lateinit var publicKeyB: PublicKey
+
+        @JvmStatic
+        @BeforeClass
+        fun setUpKeys() {
+            val keyGen = KeyPairGenerator.getInstance("RSA")
+            keyGen.initialize(1024)
+            publicKeyA = keyGen.generateKeyPair().public
+            publicKeyB = keyGen.generateKeyPair().public
+        }
+    }
 
     private lateinit var device: Device
     private lateinit var callback: PairingCallback
@@ -45,15 +61,10 @@ class PairingHandlerTest {
         callback = mockk(relaxed = true)
         sslHelper = mockk(relaxed = true)
 
-        // Generate real key pairs for deterministic verification key tests
-        val keyGen = KeyPairGenerator.getInstance("RSA")
-        keyGen.initialize(1024)
         mockCertificateA = mockk(relaxed = true)
         mockCertificateB = mockk(relaxed = true)
-        val keyPairA = keyGen.generateKeyPair()
-        val keyPairB = keyGen.generateKeyPair()
-        every { mockCertificateA.publicKey } returns keyPairA.public
-        every { mockCertificateB.publicKey } returns keyPairB.public
+        every { mockCertificateA.publicKey } returns publicKeyA
+        every { mockCertificateB.publicKey } returns publicKeyB
 
         every { sslHelper.certificate } returns mockCertificateA
         every { device.certificate } returns mockCertificateB

--- a/app/src/test/java/org/cosmic/cosmicconnect/Plugins/BatteryPlugin/BatteryExtensionsTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/Plugins/BatteryPlugin/BatteryExtensionsTest.kt
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: 2026 COSMIC Connect Contributors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+package org.cosmic.cosmicconnect.Plugins.BatteryPlugin
+
+import org.cosmic.cosmicconnect.Core.NetworkPacket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BatteryExtensionsTest {
+
+    private fun batteryPacket(
+        charge: Int = 50,
+        charging: Boolean = false,
+        thresholdEvent: Int = 0
+    ) = NetworkPacket(
+        id = 1L,
+        type = "cconnect.battery",
+        body = mapOf(
+            "currentCharge" to charge,
+            "isCharging" to charging,
+            "thresholdEvent" to thresholdEvent
+        )
+    )
+
+    // ========================================================================
+    // isBatteryPacket
+    // ========================================================================
+
+    @Test
+    fun `isBatteryPacket returns true for valid battery packet`() {
+        assertTrue(batteryPacket().isBatteryPacket)
+    }
+
+    @Test
+    fun `isBatteryPacket returns false for wrong type`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.ping",
+            body = mapOf("currentCharge" to 50, "isCharging" to false)
+        )
+        assertFalse(packet.isBatteryPacket)
+    }
+
+    @Test
+    fun `isBatteryPacket returns false for missing fields`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.battery",
+            body = mapOf("currentCharge" to 50)
+        )
+        assertFalse(packet.isBatteryPacket)
+    }
+
+    // ========================================================================
+    // Extension property extraction
+    // ========================================================================
+
+    @Test
+    fun `batteryCurrentCharge extracts charge level`() {
+        assertEquals(85, batteryPacket(charge = 85).batteryCurrentCharge)
+    }
+
+    @Test
+    fun `batteryIsCharging extracts charging status`() {
+        assertEquals(true, batteryPacket(charging = true).batteryIsCharging)
+        assertEquals(false, batteryPacket(charging = false).batteryIsCharging)
+    }
+
+    @Test
+    fun `batteryThresholdEvent extracts threshold event`() {
+        assertEquals(0, batteryPacket(thresholdEvent = 0).batteryThresholdEvent)
+        assertEquals(1, batteryPacket(thresholdEvent = 1).batteryThresholdEvent)
+    }
+
+    @Test
+    fun `extension properties return null for non-battery packet`() {
+        val packet = NetworkPacket(id = 1L, type = "cconnect.ping", body = emptyMap())
+        assertNull(packet.batteryCurrentCharge)
+        assertNull(packet.batteryIsCharging)
+        assertNull(packet.batteryThresholdEvent)
+    }
+
+    // ========================================================================
+    // isBatteryLow / isBatteryCritical
+    // ========================================================================
+
+    @Test
+    fun `isBatteryLow returns true at 14 percent not charging`() {
+        assertTrue(batteryPacket(charge = 14, charging = false).isBatteryLow)
+    }
+
+    @Test
+    fun `isBatteryLow returns false when charging`() {
+        assertFalse(batteryPacket(charge = 10, charging = true).isBatteryLow)
+    }
+
+    @Test
+    fun `isBatteryLow returns false at 15 percent`() {
+        assertFalse(batteryPacket(charge = 15, charging = false).isBatteryLow)
+    }
+
+    @Test
+    fun `isBatteryCritical returns true at 4 percent not charging`() {
+        assertTrue(batteryPacket(charge = 4, charging = false).isBatteryCritical)
+    }
+
+    @Test
+    fun `isBatteryCritical returns false when charging`() {
+        assertFalse(batteryPacket(charge = 2, charging = true).isBatteryCritical)
+    }
+
+    @Test
+    fun `isBatteryCritical returns false at 5 percent`() {
+        assertFalse(batteryPacket(charge = 5, charging = false).isBatteryCritical)
+    }
+
+    // ========================================================================
+    // DeviceBatteryInfo.fromPacket
+    // ========================================================================
+
+    @Test
+    fun `DeviceBatteryInfo fromPacket extracts all fields`() {
+        val packet = batteryPacket(charge = 75, charging = true, thresholdEvent = 0)
+        val info = DeviceBatteryInfo.fromPacket(packet)
+        assertEquals(75, info.currentCharge)
+        assertTrue(info.isCharging)
+        assertEquals(0, info.thresholdEvent)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `DeviceBatteryInfo fromPacket throws on wrong type`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.ping",
+            body = mapOf("currentCharge" to 50, "isCharging" to false)
+        )
+        DeviceBatteryInfo.fromPacket(packet)
+    }
+}

--- a/app/src/test/java/org/cosmic/cosmicconnect/Plugins/PingPlugin/PingPluginTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/Plugins/PingPlugin/PingPluginTest.kt
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: 2026 COSMIC Connect Contributors
+ *
+ * SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
+ */
+package org.cosmic.cosmicconnect.Plugins.PingPlugin
+
+import android.Manifest
+import android.app.NotificationManager
+import io.mockk.every
+import io.mockk.mockk
+import org.cosmic.cosmicconnect.Core.NetworkPacket
+import org.cosmic.cosmicconnect.Core.TransferPacket
+import org.cosmic.cosmicconnect.Device
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class PingPluginTest {
+
+    private lateinit var plugin: PingPlugin
+    private lateinit var mockDevice: Device
+    private lateinit var notificationManager: NotificationManager
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+
+        // Grant POST_NOTIFICATIONS so displayPingNotification uses NotificationManager
+        shadowOf(context).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        mockDevice = mockk(relaxed = true)
+        every { mockDevice.deviceId } returns "test-device-id"
+        every { mockDevice.name } returns "Test Device"
+
+        plugin = PingPlugin(context, mockDevice)
+
+        notificationManager = context.getSystemService(NotificationManager::class.java)
+    }
+
+    // ========================================================================
+    // onPacketReceived
+    // ========================================================================
+
+    @Test
+    fun `keepalive ping returns true and does not show notification`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.ping",
+            body = mapOf("keepalive" to true)
+        )
+        val result = plugin.onPacketReceived(TransferPacket(packet))
+        assertTrue(result)
+        assertEquals(0, shadowOf(notificationManager).size())
+    }
+
+    @Test
+    fun `message ping shows notification with message text`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.ping",
+            body = mapOf("message" to "Hello from desktop!")
+        )
+        val result = plugin.onPacketReceived(TransferPacket(packet))
+        assertTrue(result)
+
+        val shadow = shadowOf(notificationManager)
+        assertTrue(shadow.size() > 0)
+        val notification = shadow.allNotifications.first()
+        val extras = notification.extras
+        assertEquals("Hello from desktop!", extras.getCharSequence("android.text")?.toString())
+    }
+
+    @Test
+    fun `no-message ping uses default Ping text`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.ping",
+            body = emptyMap()
+        )
+        val result = plugin.onPacketReceived(TransferPacket(packet))
+        assertTrue(result)
+
+        val shadow = shadowOf(notificationManager)
+        assertTrue(shadow.size() > 0)
+        val notification = shadow.allNotifications.first()
+        val extras = notification.extras
+        assertEquals("Ping!", extras.getCharSequence("android.text")?.toString())
+    }
+
+    @Test
+    fun `wrong packet type returns false`() {
+        val packet = NetworkPacket(
+            id = 1L,
+            type = "cconnect.battery",
+            body = emptyMap()
+        )
+        val result = plugin.onPacketReceived(TransferPacket(packet))
+        assertFalse(result)
+    }
+
+    // ========================================================================
+    // Packet type arrays
+    // ========================================================================
+
+    @Test
+    fun `supportedPacketTypes contains cconnect ping`() {
+        assertArrayEquals(arrayOf("cconnect.ping"), plugin.supportedPacketTypes)
+    }
+
+    @Test
+    fun `outgoingPacketTypes contains cconnect ping`() {
+        assertArrayEquals(arrayOf("cconnect.ping"), plugin.outgoingPacketTypes)
+    }
+}

--- a/app/src/test/java/org/cosmic/cosmicconnect/Plugins/PingPlugin/PingPluginTest.kt
+++ b/app/src/test/java/org/cosmic/cosmicconnect/Plugins/PingPlugin/PingPluginTest.kt
@@ -6,6 +6,7 @@
 package org.cosmic.cosmicconnect.Plugins.PingPlugin
 
 import android.Manifest
+import android.app.Notification
 import android.app.NotificationManager
 import io.mockk.every
 import io.mockk.mockk
@@ -44,6 +45,7 @@ class PingPluginTest {
         plugin = PingPlugin(context, mockDevice)
 
         notificationManager = context.getSystemService(NotificationManager::class.java)
+        notificationManager.cancelAll()
     }
 
     // ========================================================================
@@ -76,7 +78,7 @@ class PingPluginTest {
         assertTrue(shadow.size() > 0)
         val notification = shadow.allNotifications.first()
         val extras = notification.extras
-        assertEquals("Hello from desktop!", extras.getCharSequence("android.text")?.toString())
+        assertEquals("Hello from desktop!", extras.getCharSequence(Notification.EXTRA_TEXT)?.toString())
     }
 
     @Test
@@ -93,7 +95,7 @@ class PingPluginTest {
         assertTrue(shadow.size() > 0)
         val notification = shadow.allNotifications.first()
         val extras = notification.extras
-        assertEquals("Ping!", extras.getCharSequence("android.text")?.toString())
+        assertEquals("Ping!", extras.getCharSequence(Notification.EXTRA_TEXT)?.toString())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds **57 new unit tests** across 5 test files, increasing total from 130 → 187 (+44%)
- Covers the highest-value untested code paths: pairing state machine, device identity parsing, battery extensions, ping plugin, and device name filtering
- All tests use Robolectric + MockK, no FFI calls (uses `NetworkPacket` data class constructor directly)

### New test files

| File | Tests | Coverage |
|------|-------|----------|
| `DeviceHelperTest.kt` | 9 | Name filtering, truncation, constants |
| `DeviceInfoTest.kt` | 14 | Device ID validation, identity packet parsing, DeviceType round-trips |
| `BatteryExtensionsTest.kt` | 15 | Extension properties, low/critical thresholds, DeviceBatteryInfo.fromPacket |
| `PingPluginTest.kt` | 6 | Keepalive, message/default notifications, wrong type, packet arrays |
| `PairingHandlerTest.kt` | 13 | State machine (7 transitions), v8 timestamp validation, verification keys |

## Test plan

- [x] `./gradlew testDebugUnitTest` — 187 tests, 0 failures
- [ ] Review test assertions match production behavior
- [ ] Verify no flaky tests on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)